### PR TITLE
Use function readSystemDimension

### DIFF
--- a/Modelica_LinearSystems2/DiscreteStateSpace.mo
+++ b/Modelica_LinearSystems2/DiscreteStateSpace.mo
@@ -3510,16 +3510,12 @@ The file must contain
       startTime=T_linearize,
       stopTime=T_linearize + 3*Ts);
 
-      Real nxMat[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-        fileName2,
-        "nx",
-        1,
-        1);
-      Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(
+      Integer xuy[3] = StateSpace.Internal.readSystemDimension(
         fileName2, "ABCD");
-      Integer nx=integer(nxMat[1, 1]);
-      Integer nu=ABCDsizes[2] - nx;
-      Integer ny=ABCDsizes[1] - nx;
+      Integer nx = xuy[1];
+      Integer nu = xuy[2];
+      Integer ny = xuy[3];
+
       Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
         fileName2,
         "ABCD",

--- a/Modelica_LinearSystems2/DiscreteTransferFunction.mo
+++ b/Modelica_LinearSystems2/DiscreteTransferFunction.mo
@@ -1416,13 +1416,11 @@ with
       Boolean OK1=simulateModel(problem=modelName, startTime=0, stopTime=T_linearize);
       Boolean OK2=importInitial("dsfinal.txt");
       Boolean OK3=linearizeModel(problem=modelName, resultFile=fileName, startTime=T_linearize, stopTime=T_linearize + 1);
-      Real nxMat[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-        fileName2, "nx", 1, 1);
-      Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(
+      Integer xuy[3] = StateSpace.Internal.readSystemDimension(
         fileName2, "ABCD");
-      Integer nx=integer(nxMat[1, 1]);
-      Integer nu=ABCDsizes[2] - nx;
-      Integer ny=ABCDsizes[1] - nx;
+      Integer nx = xuy[1];
+      Integer nu = xuy[2];
+      Integer ny = xuy[3];
       Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
         fileName2, "ABCD", nx + ny, nx + nu);
       String xuyName[nx + nu + ny]=readStringMatrix(fileName2, "xuyName", nx + nu + ny);

--- a/Modelica_LinearSystems2/DiscreteZerosAndPoles.mo
+++ b/Modelica_LinearSystems2/DiscreteZerosAndPoles.mo
@@ -2503,13 +2503,11 @@ second column respectively. The variable k is the real gain in both cases.
       Boolean OK1=simulateModel(problem=modelName, startTime=0, stopTime=T_linearize);
       Boolean OK2=importInitial("dsfinal.txt");
       Boolean OK3=linearizeModel(problem=modelName, resultFile=fileName, startTime=T_linearize, stopTime=T_linearize + 1);
-      Real nxMat[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-        fileName2, "nx", 1, 1);
-      Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(
+      Integer xuy[3] = StateSpace.Internal.readSystemDimension(
         fileName2, "ABCD");
-      Integer nx=integer(nxMat[1, 1]);
-      Integer nu=ABCDsizes[2] - nx;
-      Integer ny=ABCDsizes[1] - nx;
+      Integer nx = xuy[1];
+      Integer nu = xuy[2];
+      Integer ny = xuy[3];
       Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
         fileName2, "ABCD", nx + ny, nx + nu);
       String xuyName[nx + nu + ny]=readStringMatrix(fileName2, "xuyName", nx + nu + ny);

--- a/Modelica_LinearSystems2/Internal/Streams/ReadMatrixA.mo
+++ b/Modelica_LinearSystems2/Internal/Streams/ReadMatrixA.mo
@@ -7,18 +7,12 @@ function ReadMatrixA "Read the state matrix of a state space system"
     "Name of the generalized state space system matrix";
 
 protected
-  Real sizeA[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-      fileName,
-      "nx",
-      1,
-      1);
-  Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(
+  Integer xuy[3] = Modelica_LinearSystems2.StateSpace.Internal.readSystemDimension(
     fileName, matrixName);
-  Integer nx=integer(sizeA[1, 1]);
-
-  Integer nu=ABCDsizes[2] - nx;
-  Integer ny=ABCDsizes[1] - nx;
-  Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
+  Integer nx = xuy[1];
+  Integer nu = xuy[2];
+  Integer ny = xuy[3];
+  Real ABCD[nx + ny,nx + nu] = Modelica.Utilities.Streams.readRealMatrix(
       fileName,
       matrixName,
       nx + ny,

--- a/Modelica_LinearSystems2/Internal/Streams/ReadMatrixB.mo
+++ b/Modelica_LinearSystems2/Internal/Streams/ReadMatrixB.mo
@@ -1,28 +1,23 @@
 within Modelica_LinearSystems2.Internal.Streams;
 function ReadMatrixB "Read the input matrix of a state space system"
   input String fileName=DataDir + "abcd.mat"
-                              annotation(Dialog(loadSelector(filter="MAT files (*.mat);; All files (*.*)",
+    annotation(Dialog(loadSelector(filter="MAT files (*.mat);; All files (*.*)",
                       caption="state space system data file")));
   input String matrixName="ABCD"
     "Name of the generalized state space system matrix";
 
 protected
-  Real sizeA[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-      fileName,
-      "nx",
-      1,
-      1);
-  Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(
+  Integer xuy[3] = Modelica_LinearSystems2.StateSpace.Internal.readSystemDimension(
     fileName, matrixName);
-  Integer nx=integer(sizeA[1, 1]);
-  Integer nu=ABCDsizes[2] - nx;
-  Integer ny=ABCDsizes[1] - nx;
-  Real ABCD[nx + ny,nx + nu]=
-      Modelica.Utilities.Streams.readRealMatrix(
+  Integer nx = xuy[1];
+  Integer nu = xuy[2];
+  Integer ny = xuy[3];
+  Real ABCD[nx + ny,nx + nu] = Modelica.Utilities.Streams.readRealMatrix(
       fileName,
       matrixName,
       nx + ny,
       nx + nu);
+
 public
   output Real B[nx,nu]=ABCD[1:nx, nx + 1:nx + nu];
 algorithm

--- a/Modelica_LinearSystems2/Internal/Streams/ReadMatrixC.mo
+++ b/Modelica_LinearSystems2/Internal/Streams/ReadMatrixC.mo
@@ -1,28 +1,23 @@
 within Modelica_LinearSystems2.Internal.Streams;
 function ReadMatrixC "Read the output matrix of a state space system"
   input String fileName=DataDir + "abcd.mat"
-                              annotation(Dialog(loadSelector(filter="MAT files (*.mat);; All files (*.*)",
+    annotation(Dialog(loadSelector(filter="MAT files (*.mat);; All files (*.*)",
                       caption="state space system data file")));
   input String matrixName="ABCD"
     "Name of the generalized state space system matrix";
 
 protected
-  Real sizeA[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-      fileName,
-      "nx",
-      1,
-      1);
-  Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(
+  Integer xuy[3] = Modelica_LinearSystems2.StateSpace.Internal.readSystemDimension(
     fileName, matrixName);
-  Integer nx=integer(sizeA[1, 1]);
-  Integer nu=ABCDsizes[2] - nx;
-  Integer ny=ABCDsizes[1] - nx;
-  Real ABCD[nx + ny,nx + nu]=
-      Modelica.Utilities.Streams.readRealMatrix(
+  Integer nx = xuy[1];
+  Integer nu = xuy[2];
+  Integer ny = xuy[3];
+  Real ABCD[nx + ny,nx + nu] = Modelica.Utilities.Streams.readRealMatrix(
       fileName,
       matrixName,
       nx + ny,
       nx + nu);
+
 public
   output Real C[ny,nx]=ABCD[nx + 1:nx + ny, 1:nx];
 algorithm

--- a/Modelica_LinearSystems2/Internal/Streams/ReadMatrixD.mo
+++ b/Modelica_LinearSystems2/Internal/Streams/ReadMatrixD.mo
@@ -1,28 +1,23 @@
 within Modelica_LinearSystems2.Internal.Streams;
 function ReadMatrixD "Read the feed forward matrix of a state space system"
   input String fileName=DataDir + "abcd.mat"
-                              annotation(Dialog(loadSelector(filter="MAT files (*.mat);; All files (*.*)",
+    annotation(Dialog(loadSelector(filter="MAT files (*.mat);; All files (*.*)",
                       caption="state space system data file")));
   input String matrixName="ABCD"
     "Name of the generalized state space system matrix";
 
 protected
-  Real sizeA[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-      fileName,
-      "nx",
-      1,
-      1);
-  Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(
+  Integer xuy[3] = Modelica_LinearSystems2.StateSpace.Internal.readSystemDimension(
     fileName, matrixName);
-  Integer nx=integer(sizeA[1, 1]);
-  Integer nu=ABCDsizes[2] - nx;
-  Integer ny=ABCDsizes[1] - nx;
-  Real ABCD[nx + ny,nx + nu]=
-      Modelica.Utilities.Streams.readRealMatrix(
+  Integer nx = xuy[1];
+  Integer nu = xuy[2];
+  Integer ny = xuy[3];
+  Real ABCD[nx + ny,nx + nu] = Modelica.Utilities.Streams.readRealMatrix(
       fileName,
       matrixName,
       nx + ny,
       nx + nu);
+
 public
   output Real D[ny,nu]=ABCD[nx + 1:nx + ny, nx + 1:nx + nu];
 algorithm

--- a/Modelica_LinearSystems2/StateSpace.mo
+++ b/Modelica_LinearSystems2/StateSpace.mo
@@ -9697,15 +9697,11 @@ Reads and loads a state space system from a mat-file <tt>fileName</tt>. The file
               stopTime=T_linearize + 1,
               method=method);
 
-      Real nxMat[1, 1]=Modelica.Utilities.Streams.readRealMatrix(
-              fileName2,
-              "nx",
-              1,
-              1);
-      Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(fileName2, "ABCD");
-      Integer nx=integer(nxMat[1, 1]);
-      Integer nu=ABCDsizes[2] - nx;
-      Integer ny=ABCDsizes[1] - nx;
+      Integer xuy[3] = StateSpace.Internal.readSystemDimension(
+        fileName2, "ABCD");
+      Integer nx = xuy[1];
+      Integer nu = xuy[2];
+      Integer ny = xuy[3];
       Real ABCD[nx + ny, nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
               fileName2,
               "ABCD",
@@ -12718,15 +12714,11 @@ k = ---------- * ----------------------
     protected
       String fileName2=fileName + ".mat"
         "Name of the result file with extension";
-      Real nxMat[1, 1]=Modelica.Utilities.Streams.readRealMatrix(
-              fileName2,
-              "nx",
-              1,
-              1);
-      Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(fileName2, "ABCD");
-      Integer nx=integer(nxMat[1, 1]);
-      Integer nu=ABCDsizes[2] - nx;
-      Integer ny=ABCDsizes[1] - nx;
+      Integer xuy[3] = StateSpace.Internal.readSystemDimension(
+        fileName2, "ABCD");
+      Integer nx = xuy[1];
+      Integer nu = xuy[2];
+      Integer ny = xuy[3];
       Real ABCD[nx + ny, nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
               fileName2,
               "ABCD",

--- a/Modelica_LinearSystems2/StateSpace.mo
+++ b/Modelica_LinearSystems2/StateSpace.mo
@@ -11876,7 +11876,7 @@ The uncontrollable poles are checked to to stable.
                 "State space system data file")));
       input String matrixName="ABCD"
         "Name of the generalized state space system matrix";
-      output Integer xuy[3];
+      output Integer xuy[3] "Order of matrixName; size of u; size of y";
 
     protected
       Real sizeA[1, 1]=Streams.readRealMatrix(

--- a/Modelica_LinearSystems2/StateSpace.mo
+++ b/Modelica_LinearSystems2/StateSpace.mo
@@ -11654,7 +11654,7 @@ The uncontrollable poles are checked to to stable.
 
     encapsulated function readLength_nu
       "Read the number of inputs nu of a state space system from a file"
-      import Modelica.Utilities.Streams;
+      import Modelica_LinearSystems2.StateSpace.Internal.readSystemDimension;
 
       input String fileName="ss_siso.mat"
         "Name of the state space system data file" annotation (Dialog(
@@ -11665,16 +11665,10 @@ The uncontrollable poles are checked to to stable.
 
       output Integer nu;
     protected
-      Real nxMat[1, 1]=Streams.readRealMatrix(
-              fileName,
-              "nx",
-              1,
-              1);
-      Integer ABCDsizes[2]=Streams.readMatrixSize(fileName, matrixName);
-      Integer nx=integer(nxMat[1, 1]);
+      Integer xuy[3] = readSystemDimension(fileName, matrixName);
 
     algorithm
-      nu := ABCDsizes[2] - nx;
+      nu := xuy[2];
     end readLength_nu;
 
     encapsulated function readLength_nx
@@ -11698,7 +11692,7 @@ The uncontrollable poles are checked to to stable.
 
     encapsulated function readLength_ny
       "Read the number of outputs ny of a state space system from a file"
-      import Modelica.Utilities.Streams;
+      import Modelica_LinearSystems2.StateSpace.Internal.readSystemDimension;
 
       input String fileName="ss_siso.mat"
         "Name of the state space system data file" annotation (Dialog(
@@ -11709,16 +11703,10 @@ The uncontrollable poles are checked to to stable.
 
       output Integer ny;
     protected
-      Real nxMat[1, 1]=Streams.readRealMatrix(
-              fileName,
-              "nx",
-              1,
-              1);
-      Integer ABCDsizes[2]=Streams.readMatrixSize(fileName, matrixName);
-      Integer nx=integer(nxMat[1, 1]);
+      Integer xuy[3] = readSystemDimension(fileName, matrixName);
 
     algorithm
-      ny := ABCDsizes[1] - nx;
+      ny := xuy[3];
     end readLength_ny;
 
     encapsulated function reducedCtrSystem2

--- a/Modelica_LinearSystems2/TransferFunction.mo
+++ b/Modelica_LinearSystems2/TransferFunction.mo
@@ -2562,11 +2562,11 @@ Reads and loads a transfer function from a mat-file <tt>fileName</tt>. The file 
       Boolean OK1 = simulateModel(problem=modelName, startTime=0, stopTime=T_linearize);
       Boolean OK2 = importInitial("dsfinal.txt");
       Boolean OK3 = linearizeModel(problem=modelName, resultFile=fileName, startTime=T_linearize, stopTime=T_linearize+1);
-      Real nxMat[1,1]=Modelica.Utilities.Streams.readRealMatrix(fileName2, "nx", 1, 1);
-      Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(fileName2, "ABCD");
-      Integer nx=integer(nxMat[1, 1]);
-      Integer nu=ABCDsizes[2] - nx;
-      Integer ny=ABCDsizes[1] - nx;
+      Integer xuy[3] = StateSpace.Internal.readSystemDimension(
+        fileName2, "ABCD");
+      Integer nx = xuy[1];
+      Integer nu = xuy[2];
+      Integer ny = xuy[3];
       Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(fileName2, "ABCD", nx + ny, nx + nu);
       String xuyName[nx + nu + ny]=readStringMatrix(fileName2, "xuyName", nx + nu + ny);
 

--- a/Modelica_LinearSystems2/Utilities/Import/linearize.mo
+++ b/Modelica_LinearSystems2/Utilities/Import/linearize.mo
@@ -14,11 +14,11 @@ protected
   Boolean OK3 = linearizeModel(problem=modelName, resultFile=fileName, startTime=t_linearize, stopTime=t_linearize);
 
   // Read linear system from file
-  Real nxMat[1,1]=Modelica.Utilities.Streams.readRealMatrix(fileName2, "nx", 1, 1);
-  Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(fileName2, "ABCD");
-  Integer nx=integer(nxMat[1, 1]);
-  Integer nu=ABCDsizes[2] - nx;
-  Integer ny=ABCDsizes[1] - nx;
+  Integer xuy[3] = StateSpace.Internal.readSystemDimension(
+    fileName2, "ABCD");
+  Integer nx = xuy[1];
+  Integer nu = xuy[2];
+  Integer ny = xuy[3];
   Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(fileName2, "ABCD", nx + ny, nx + nu);
   String xuyName[nx + nu + ny]=readStringMatrix(fileName2, "xuyName", nx + nu + ny);
 

--- a/Modelica_LinearSystems2/Utilities/Import/linearize2.mo
+++ b/Modelica_LinearSystems2/Utilities/Import/linearize2.mo
@@ -51,15 +51,11 @@ protected
       stopTime=simulationSetup.t_linearize);
 
   // Read linear system from file
-  Real nxMat[1, 1]=Modelica.Utilities.Streams.readRealMatrix(
-      fileName2,
-      "nx",
-      1,
-      1);
-  Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(fileName2, "ABCD");
-  Integer nx=integer(nxMat[1, 1]);
-  Integer nu=ABCDsizes[2] - nx;
-  Integer ny=ABCDsizes[1] - nx;
+  Integer xuy[3] = Modelica_LinearSystems2.StateSpace.Internal.readSystemDimension(
+    fileName2, "ABCD");
+  Integer nx = xuy[1];
+  Integer nu = xuy[2];
+  Integer ny = xuy[3];
   Real ABCD[nx + ny, nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
       fileName2,
       "ABCD",

--- a/Modelica_LinearSystems2/Utilities/Import/rootLocusOfModel.mo
+++ b/Modelica_LinearSystems2/Utilities/Import/rootLocusOfModel.mo
@@ -32,8 +32,7 @@ protected
 
   String fileName="dslin";
   String fileName2;
-  Real nxMat[1, 1];
-  Integer ABCDsizes[2];
+  Integer xuy[3];
   Integer nx;
   Integer nu;
   Integer ny;
@@ -170,15 +169,10 @@ algorithm
 
   // Determine array dimensions of the first linearization point
   fileName2 := fileName + String(is[1]) + ".mat";
-  nxMat := Modelica.Utilities.Streams.readRealMatrix(
-    fileName2,
-    "nx",
-    1,
-    1);
-  ABCDsizes := Modelica.Utilities.Streams.readMatrixSize(fileName2, "ABCD");
-  nx := integer(nxMat[1, 1]);
-  nu := ABCDsizes[2] - nx;
-  ny := ABCDsizes[1] - nx;
+  xuy :=StateSpace.Internal.readSystemDimension(fileName2, "ABCD");
+  nx :=xuy[1];
+  nu :=xuy[2];
+  ny :=xuy[3];
 
   // Read all matrices from file, compute eigenvalues and store them in output arrays
   (Re,Im) := Modelica_LinearSystems2.Internal.eigenValuesFromLinearization(

--- a/Modelica_LinearSystems2/WorkInProgress/DiscreteZerosAndPoles.mo
+++ b/Modelica_LinearSystems2/WorkInProgress/DiscreteZerosAndPoles.mo
@@ -1319,15 +1319,11 @@ processing.
           resultFile=fileName,
           startTime=T_linearize,
           stopTime=T_linearize + 1);
-    Real nxMat[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-          fileName2,
-          "nx",
-          1,
-          1);
-    Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(fileName2, "ABCD");
-    Integer nx=integer(nxMat[1, 1]);
-    Integer nu=ABCDsizes[2] - nx;
-    Integer ny=ABCDsizes[1] - nx;
+    Integer xuy[3] = StateSpace.Internal.readSystemDimension(
+      fileName2, "ABCD");
+    Integer nx = xuy[1];
+    Integer nu = xuy[2];
+    Integer ny = xuy[3];
     Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
           fileName2,
           "ABCD",

--- a/Modelica_LinearSystems2/WorkInProgress/RootLocusOld.mo
+++ b/Modelica_LinearSystems2/WorkInProgress/RootLocusOld.mo
@@ -260,11 +260,11 @@ over the load inertia <b>Jload</b>:
     Boolean OK3 = linearizeModel(problem=modelName, resultFile=fileName, startTime=t_linearize, stopTime=t_linearize);
 
     // Read linear system from file
-    Real nxMat[1,1]=Modelica.Utilities.Streams.readRealMatrix(fileName2, "nx", 1, 1);
-    Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(fileName2, "ABCD");
-    Integer nx=integer(nxMat[1, 1]);
-    Integer nu=ABCDsizes[2] - nx;
-    Integer ny=ABCDsizes[1] - nx;
+    Integer xuy[3] = Modelica_LinearSystems2.StateSpace.Internal.readSystemDimension(
+      fileName2, "ABCD");
+    Integer nx = xuy[1];
+    Integer nu = xuy[2];
+    Integer ny = xuy[3];
     Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(fileName2, "ABCD", nx + ny, nx + nu);
   public
     output Real A[nx,nx] =  ABCD[1:nx, 1:nx] "A-matrix";

--- a/Modelica_LinearSystems2/ZerosAndPoles.mo
+++ b/Modelica_LinearSystems2/ZerosAndPoles.mo
@@ -4240,16 +4240,11 @@ Reads and loads a zeros-and-poles transfer function from a mat-file <tt>fileName
             resultFile=fileName,
             startTime=T_linearize,
             stopTime=T_linearize + 1);
-      Real nxMat[1,1]=Modelica.Utilities.Streams.readRealMatrix(
-            fileName2,
-            "nx",
-            1,
-            1);
-      Integer ABCDsizes[2]=Modelica.Utilities.Streams.readMatrixSize(
+      Integer xuy[3] = StateSpace.Internal.readSystemDimension(
         fileName2, "ABCD");
-      Integer nx=integer(nxMat[1, 1]);
-      Integer nu=ABCDsizes[2] - nx;
-      Integer ny=ABCDsizes[1] - nx;
+      Integer nx = xuy[1];
+      Integer nu = xuy[2];
+      Integer ny = xuy[3];
       Real ABCD[nx + ny,nx + nu]=Modelica.Utilities.Streams.readRealMatrix(
             fileName2,
             "ABCD",


### PR DESCRIPTION
Use function readSystemDimension for dimensioning of state space matrices instead of calling readRealMatrix and readMatrixSize subsequently.