### PR TITLE
Set initial value of matrix ABCD

### DIFF
--- a/Modelica_LinearSystems2/Controller/Internal/DiscreteStateSpace2.mo
+++ b/Modelica_LinearSystems2/Controller/Internal/DiscreteStateSpace2.mo
@@ -6,7 +6,7 @@ model DiscreteStateSpace2
   import Modelica_LinearSystems2.Controller.Types;
   import Modelica.Math.Matrices;
 
-  parameter Real ABCD[:,:] "Continuous linear time-invariant system"
+  parameter Real ABCD[:,:] = zeros(2,2) "Continuous linear time-invariant system"
     annotation(HideResult=true);
 
 protected


### PR DESCRIPTION
Resolves Dymolas warning
```
Failed to expand the variable A and its definition equation: ABCD[1:end-1, 1:end-1]
```

cf. 5a2e1a36493c444aedb8fb0b2955d686820b0d50 and 50e0ce19adb294c2bb3fafe5eca3f16bdab45dc2
