### PR TITLE
Fix crash when running Inverse Pendulum by having place for output.

### DIFF
--- a/Modelica_LinearSystems2/Math/Matrices/LAPACK/dgesvx.mo
+++ b/Modelica_LinearSystems2/Math/Matrices/LAPACK/dgesvx.mo
@@ -13,7 +13,7 @@ function dgesvx
 
 protected
   String transA= if transposed then "T" else "N";
-  String equed; // Is output since FACT = 'N', i.e. first parameter = 'N'
+  String equed = " "; // Is output since FACT = 'N', i.e. first parameter = 'N'
   Integer n=size(A, 1);
   Integer nrhs=size(B, 2);
   Real Awork[n,n]=A;

--- a/Modelica_LinearSystems2/package.mo
+++ b/Modelica_LinearSystems2/package.mo
@@ -12,7 +12,7 @@ annotation (
   uses(Modelica(version="4.0.0")),
   version="2.4.0",
   versionDate="2020-06-26",
-  dateModified = "2020-06-26 14:00:00Z",
+  dateModified = "2023-08-29 10:00:00Z",
   revisionId="$Id::                                       $",
   conversion(
     from(version={"2.0", "2.1", "2.2", "2.3", "2.3.1", "2.3.2", "2.3.2", "2.3.3", "2.3.4"},


### PR DESCRIPTION
I know that this is fixed in master, but if someone use the old version it will fail hard when used.
It uses the same code as in MSL to be safer.