### PR TITLE
Modify parameters of inverseDoublePendulum

### DIFF
--- a/Modelica_LinearSystems2/Controllers/Examples/Utilities/InverseDoublePendulum2.mo
+++ b/Modelica_LinearSystems2/Controllers/Examples/Utilities/InverseDoublePendulum2.mo
@@ -46,7 +46,10 @@ model InverseDoublePendulum2 "Inverted double pendulum"
     w1_start=w1_start,
     w2_start=w2_start,
     cartDisturbance=cartDisturbance,
-    bodyDisturbance=bodyDisturbance) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+    bodyDisturbance=bodyDisturbance,
+    bodyCylinder(diameter=0.03, density=1000),
+    bodyCylinder1(diameter=0.03, density=1000),
+    const(k=-0.5*Modelica.Constants.pi)) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   Modelica.Blocks.Routing.Multiplex6 multiplex6
     annotation (Placement(transformation(extent={{20,-10},{40,10}})));
   Modelica.Blocks.Interfaces.RealInput dist if cartDisturbance

--- a/Modelica_LinearSystems2/Controllers/Examples/Utilities/InverseDoublePendulum3.mo
+++ b/Modelica_LinearSystems2/Controllers/Examples/Utilities/InverseDoublePendulum3.mo
@@ -50,7 +50,10 @@ model InverseDoublePendulum3 "Inverted double pendulum"
     w1_start=w1_start,
     w2_start=w2_start,
     cartDisturbance=cartDisturbance,
-    bodyDisturbance=bodyDisturbance)
+    bodyDisturbance=bodyDisturbance,
+    bodyCylinder(diameter=0.03, density=1000),
+    bodyCylinder1(diameter=0.03, density=1000),
+    const(k=-0.5*Modelica.Constants.pi))
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
   Modelica.Blocks.Routing.Multiplex6 multiplex6
     annotation (Placement(transformation(extent={{20,-10},{40,10}})));


### PR DESCRIPTION
...since the parametrs considered in the examples 
- `M_LS2.Controllers.Examples.InverseDoublePendulum` and
- `M_LS2.Controllers.Examples.InverseDoublePendulumWithObserver`

are different to params in the base model `M_LS2.Utilities.Plants.DoublePendulumInverse`.

Addendum of #203

See also #153 